### PR TITLE
Showing/hiding Nexus modules based on permissions

### DIFF
--- a/nexus/modules.py
+++ b/nexus/modules.py
@@ -30,6 +30,8 @@ class NexusModule(object):
         return self.site.render_to_response(template, context, request, current_app=self.name)
 
     def as_view(self, *args, **kwargs):
+        if 'extra_permission' not in kwargs:
+            kwargs['extra_permission'] = self.permission
         return self.site.as_view(*args, **kwargs)
     
     def get_context(self, request):

--- a/nexus/templatetags/nexus_helpers.py
+++ b/nexus/templatetags/nexus_helpers.py
@@ -19,6 +19,9 @@ def show_navigation(context):
         if not module.home_url:
             continue
 
+        if module.permission and not request.user.has_perm(module.permission):
+            continue
+
         home_url = reverse(module.get_home_url(), current_app=module.name)
 
         active = request.path.startswith(home_url)


### PR DESCRIPTION
A nexus module has a "permission" attribute which, if set, is checked when showing the dashboard (navigation and panels) and each page of the module (if "self.as_view" is used for the views). This means you can limit modules to specific permissions. I've used django auth's permissions - since a permission has to be related to a model I haven't automated permission creation.

It's pretty simple and I think I'm happy enough with how it works. Happy to make any changes based on feedback.
