### PR TITLE
Use django media url

### DIFF
--- a/nexus/conf.py
+++ b/nexus/conf.py
@@ -1,3 +1,6 @@
 from django.conf import settings
 
 MEDIA_PREFIX = getattr(settings, 'NEXUS_MEDIA_PREFIX', '/nexus/media/')
+
+if getattr(settings, 'NEXUS_USE_DJANGO_MEDIA_URL', False):
+    MEDIA_PREFIX = getattr(settings, 'MEDIA_URL', MEDIA_PREFIX)


### PR DESCRIPTION
Add a setting NEXUS_USE_DJANGO_MEDIA_URL to easily use Django's MEDIA_URL for the nexus MEDIA_PREFIX.

If you want to make custom modifications to the nexus media it makes sense to have it under your own app's media folder and the NEXUS_USE_DJANGO_MEDIA_URL allows the MEDIA_URL to be DRY. This repetition would be a hassle if you have multiple settings files with their own MEDIA_URLs and having to then repeat the NEXUS_MEDIA_PREFIX in each settings file.
