### PR TITLE
not everyone uses django auth, don't couple nexus to it.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,6 +41,8 @@ Now you'll want to include it within your ``urls.py``::
 	    ('^nexus/', include(nexus.site.urls)),
 	)
 
+By default Nexus requires django.contrib.auth and django.contrib.sessions. If you are using a custom auth system you can skip these requirements by using the setting ``NEXUS_SKIP_INSTALLED_APPS_REQUIREMENTS = True`` in your django settings.
+
 Modules
 =======
 

--- a/nexus/models.py
+++ b/nexus/models.py
@@ -2,6 +2,8 @@ from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 
 _reqs = ('django.contrib.auth', 'django.contrib.sessions')
+if getattr(settings, 'NEXUS_SKIP_INSTALLED_APPS_REQUIREMENTS', False):
+    _reqs = ()
 for r in _reqs:
     if r not in settings.INSTALLED_APPS:
         raise ImproperlyConfigured("Put '%s' in your "


### PR DESCRIPTION
if you aren't using django's auth system the NEXUS_SKIP_INSTALLED_APPS_REQUIREMENTS setting allows you to bypass this requirements check.
