### PR TITLE
Use functools.update_wrapper for Django 1.6+ / Python 2.5+

### DIFF
--- a/example_module/nexus_modules.py
+++ b/example_module/nexus_modules.py
@@ -8,7 +8,7 @@ class HelloWorldModule(nexus.NexusModule):
         return 'Hello World'
 
     def get_urls(self):
-        from django.conf.urls.defaults import patterns, url
+        from django.conf.urls import patterns, url
 
         urlpatterns = patterns('',
             url(r'^$', self.as_view(self.index), name='index'),

--- a/example_project/urls.py
+++ b/example_project/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import patterns, include, url
+from django.conf.urls import patterns, include, url
 
 from django.contrib import admin
 

--- a/nexus/modules.py
+++ b/nexus/modules.py
@@ -105,7 +105,12 @@ class NexusModule(object):
         return self.get_title()
 
     def get_urls(self):
-        from django.conf.urls.defaults import patterns
+        try:
+            from django.conf.urls import patterns
+        except ImportError:
+            # django.conf.urls.defaults deprecated in django 1.4, removed in django 1.6
+            # this try/except can be removed when nexus drops support for django 1.3
+            from django.conf.urls.defaults import patterns
 
         return patterns('')
 

--- a/nexus/sites.py
+++ b/nexus/sites.py
@@ -81,7 +81,12 @@ class NexusSite(object):
             del self._registry[namespace]
 
     def get_urls(self):
-        from django.conf.urls.defaults import patterns, url, include
+        try:
+            from django.conf.urls import patterns, url, include
+        except ImportError:
+            # django.conf.urls.defaults deprecated in django 1.4, removed in django 1.6
+            # this try/except can be removed when nexus drops support for django 1.3
+            from django.conf.urls.defaults import patterns, url, include
 
         base_urls = patterns('',
             url(r'^media/(?P<module>[^/]+)/(?P<path>.+)$', self.media, name='media'),


### PR DESCRIPTION
This fixes https://github.com/dcramer/nexus/issues/31

update_wrapper is no longer in django.utils.functional as of Django 1.6, since it has been part of the Python standard library's functools package since Python 2.5.  The import's been changed (and the usage has also been changed to use the package name for consistent coding style -- it seems that stdlib packages aren't imported with "from" in this project, or at least in this file).
