### PR TITLE
Fix footer Disqus link

### DIFF
--- a/nexus/templates/nexus/base.html
+++ b/nexus/templates/nexus/base.html
@@ -94,7 +94,7 @@
 
         <div id="footer">
             <div class="wrapper">
-                Nexus {% nexus_version %} | Powered by sexy Django magic | Conjured up by the <a href="http://code.disqus.com">DISQUS</a> team and other noble <a href="https://github.com/dcramer/nexus/contributors">sorcerers</a>.
+                Nexus {% nexus_version %} | Powered by sexy Django magic | Conjured up by the <a href="http://engineering.disqus.com">DISQUS</a> team and other noble <a href="https://github.com/dcramer/nexus/contributors">sorcerers</a>.
             </div>
         </div>
     </body>


### PR DESCRIPTION
The previous footer linked to http://code.disqus.com, which would ask for credentials with intention of authenticating for the `code` forum's admin page.
