### PR TITLE
Stop using deprecated kwarg

### DIFF
--- a/nexus/sites.py
+++ b/nexus/sites.py
@@ -242,9 +242,9 @@ class NexusSite(object):
         mimetype = mimetypes.guess_type(fullpath)[0] or 'application/octet-stream'
         if not was_modified_since(request.META.get('HTTP_IF_MODIFIED_SINCE'),
                                   statobj[stat.ST_MTIME], statobj[stat.ST_SIZE]):
-            return HttpResponseNotModified(mimetype=mimetype)
+            return HttpResponseNotModified(content_type=mimetype)
         contents = open(fullpath, 'rb').read()
-        response = HttpResponse(contents, mimetype=mimetype)
+        response = HttpResponse(contents, content_type=mimetype)
         response["Last-Modified"] = http_date(statobj[stat.ST_MTIME])
         response["Content-Length"] = len(contents)
         return response


### PR DESCRIPTION
As far as I know, this is all that's required for Django 1.7 support and
is backwards compatible to Django 1.4.

More info: https://code.djangoproject.com/ticket/19692