### PR TITLE
#19 Load csrf cookie name from django settings

### DIFF
--- a/nexus/conf.py
+++ b/nexus/conf.py
@@ -1,6 +1,7 @@
 from django.conf import settings
 
 MEDIA_PREFIX = getattr(settings, 'NEXUS_MEDIA_PREFIX', '/nexus/media/')
+CSRF_COOKIE_NAME = getattr(settings, 'CSRF_COOKIE_NAME', 'csrftoken')
 
 if getattr(settings, 'NEXUS_USE_DJANGO_MEDIA_URL', False):
     MEDIA_PREFIX = getattr(settings, 'MEDIA_URL', MEDIA_PREFIX)

--- a/nexus/media/js/nexus.js
+++ b/nexus/media/js/nexus.js
@@ -34,7 +34,7 @@ jQuery.ajaxSetup({
         }
 
         if (!safeMethod(settings.type) && sameOrigin(settings.url)) {
-            xhr.setRequestHeader("X-CSRFToken", getCookie('csrftoken'));
+            xhr.setRequestHeader("X-CSRFToken", getCookie(window.__nexus_csrf_cookie_name__));
         }
     }
 });

--- a/nexus/templates/nexus/base.html
+++ b/nexus/templates/nexus/base.html
@@ -22,6 +22,10 @@
             };
         </script>
 
+        <script type="text/javascript">
+            window.__nexus_csrf_cookie_name__ = "{% nexus_csrf_cookie_name %}";
+        </script>
+
         <script src="{% nexus_media_prefix %}/nexus/js/lib/jquery.js"></script>
         <script src="{% nexus_media_prefix %}/nexus/js/lib/jquery.tmpl.js"></script>
         <script src="{% nexus_media_prefix %}/nexus/js/lib/facebox/facebox.js"></script>

--- a/nexus/templatetags/nexus_helpers.py
+++ b/nexus/templatetags/nexus_helpers.py
@@ -13,6 +13,11 @@ def nexus_media_prefix():
 register.simple_tag(nexus_media_prefix)
 
 
+def nexus_csrf_cookie_name():
+    return conf.CSRF_COOKIE_NAME
+register.simple_tag(nexus_csrf_cookie_name)
+
+
 def nexus_version():
     return nexus.VERSION
 register.simple_tag(nexus_version)


### PR DESCRIPTION
If someone changes csrf cookie name in project settings, then nexus admin will not work (403 error). This will fix it (write `CSRF_COOKIE_NAME` value to js variable and use it it ajax settings instead of default).
Fix for #19 
