### PR TITLE
Update deprecation notice to point to the YPlan fork

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,7 @@
 NOTICE: Deprecated
 ------------------
-This project is deprecated and no longer actively maintained by Disqus.
+
+This project is deprecated and no longer actively maintained by `Disqus <https://disqus.com/>`_. However there is a fork being maintained by YPlan at `github.com/YPlan/nexus <https://github.com/YPlan/nexus>`_.
 
 Nexus
 -----


### PR DESCRIPTION
Our fork is compatible with Python 3 and the latest versions of Django, and available on PyPI as `nexus-yplan`.